### PR TITLE
Fix jenkins tests

### DIFF
--- a/src/test/java/org/gdms/gdmstopology/TopologySetUpTest.java
+++ b/src/test/java/org/gdms/gdmstopology/TopologySetUpTest.java
@@ -32,7 +32,6 @@
  */
 package org.gdms.gdmstopology;
 
-import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.io.WKTReader;
 import java.io.File;
 import org.gdms.data.DataSourceFactory;
@@ -52,7 +51,7 @@ public abstract class TopologySetUpTest {
     protected String GRAPH2D_EDGES = "graph2D_edges";
     protected String GRAPH2D_NODES = "graph2D_nodes";
     public static String internalData = "src/test/resources/org/gdms/gdmstopology/";
-    public static File backupDir = new File(System.getProperty("user.home") + File.separator + ".gdmstopology");
+    public static File backupDir = new File("./target/gdmstopology");
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/gdms/gdmstopology/TopologySetUpTest.java
+++ b/src/test/java/org/gdms/gdmstopology/TopologySetUpTest.java
@@ -40,39 +40,88 @@ import org.junit.Before;
 import org.orbisgis.utils.FileUtils;
 
 /**
+ * Registers some data sources for use in unit tests.
  *
- * @author Erwan Bocher
+ * @author Erwan Bocher, Adam Gouge
  */
 public abstract class TopologySetUpTest {
 
+    /**
+     * Data source factory.
+     */
     protected DataSourceFactory dsf;
+    /**
+     * Well-known text reader for constructing geometries.
+     */
     protected WKTReader wktReader;
+    /**
+     * 2D graph.
+     */
     protected String GRAPH2D = "graph2D";
+    /**
+     * 2D graph edges.
+     */
     protected String GRAPH2D_EDGES = "graph2D_edges";
+    /**
+     * 2D graph nodes.
+     */
     protected String GRAPH2D_NODES = "graph2D_nodes";
-    public static String internalData = "src/test/resources/org/gdms/gdmstopology/";
-    public static File backupDir = new File("./target/gdmstopology");
+    /**
+     * The shape file extension.
+     */
+    private static final String DOT_SHP = ".shp";
+    /**
+     * The resources folder.
+     */
+    private static final String resourcesFolder =
+            "src/test/resources/org/gdms/gdmstopology/";
+    /**
+     * Temporary folder for saving results.
+     */
+    public static File tmpFolder = new File("./target/gdmstopology");
 
+    /**
+     * Creates the temp folder and registers some data sources.
+     *
+     * @throws Exception
+     */
     @Before
     public void setUp() throws Exception {
-        if (backupDir.exists()) {
-            //Create a folder to save all results
-            FileUtils.deleteDir(backupDir);
-        }
-        backupDir.mkdir();
-        //Create the datasourcefactory that uses the folder
-        dsf = new DataSourceFactory(backupDir.getAbsolutePath(), backupDir.getAbsolutePath());
 
-        //Create some geometries
+        // Make the temp folder, deleting any previous temp folder.
+        if (tmpFolder.exists()) {
+            FileUtils.deleteDir(tmpFolder);
+        }
+        tmpFolder.mkdir();
+
+        // Initialize the DataSourceFactory that uses the folder.
+        // We store both the sources and the temporary sources in the
+        // temp folder.
+        dsf = new DataSourceFactory(tmpFolder.getAbsolutePath(),
+                                    tmpFolder.getAbsolutePath());
+
+        // Initialize the WKTReader.
         wktReader = new WKTReader();
-        dsf.getSourceManager().register(GRAPH2D, new File(internalData + "graph2D.shp"));
-        dsf.getSourceManager().register(GRAPH2D_EDGES, new File(internalData + "graph2D_edges.shp"));
-        dsf.getSourceManager().register(GRAPH2D_NODES, new File(internalData + "graph2D_nodes.shp"));
+
+        // Register some data sources.
+        dsf.getSourceManager()
+                .register(GRAPH2D,
+                          new File(resourcesFolder + GRAPH2D + DOT_SHP));
+        dsf.getSourceManager()
+                .register(GRAPH2D_EDGES,
+                          new File(resourcesFolder + GRAPH2D_EDGES + DOT_SHP));
+        dsf.getSourceManager()
+                .register(GRAPH2D_NODES,
+                          new File(resourcesFolder + GRAPH2D_NODES + DOT_SHP));
     }
 
+    /**
+     * Deletes the temp folder.
+     *
+     * @throws Exception
+     */
     @After
     public void tearDown() throws Exception {
-        //Delete the folder that contains result
-        FileUtils.deleteDir(backupDir);
+        FileUtils.deleteDir(tmpFolder);
     }
 }

--- a/src/test/java/org/gdms/gdmstopology/TopologySetupTest.java
+++ b/src/test/java/org/gdms/gdmstopology/TopologySetupTest.java
@@ -44,7 +44,7 @@ import org.orbisgis.utils.FileUtils;
  *
  * @author Erwan Bocher, Adam Gouge
  */
-public abstract class TopologySetUpTest {
+public abstract class TopologySetupTest {
 
     /**
      * Data source factory.

--- a/src/test/java/org/gdms/gdmstopology/function/CentralityTest.java
+++ b/src/test/java/org/gdms/gdmstopology/function/CentralityTest.java
@@ -36,7 +36,7 @@ import org.gdms.data.DataSource;
 import org.gdms.driver.DataSet;
 import org.gdms.driver.DiskBufferDriver;
 import org.gdms.driver.DriverException;
-import org.gdms.gdmstopology.TopologySetUpTest;
+import org.gdms.gdmstopology.TopologySetupTest;
 import org.gdms.gdmstopology.model.GraphSchema;
 import org.gdms.gdmstopology.model.WMultigraphDataSource;
 import org.gdms.gdmstopology.process.GraphCentralityUtilities;
@@ -50,7 +50,7 @@ import org.orbisgis.progress.ProgressMonitor;
  *
  * @author Adam Gouge
  */
-public class CentralityTest extends TopologySetUpTest {
+public class CentralityTest extends TopologySetupTest {
 
     /**
      * Test the closeness centrality calculation on a 2D graph considered as an

--- a/src/test/java/org/gdms/gdmstopology/function/ConnectivityTest.java
+++ b/src/test/java/org/gdms/gdmstopology/function/ConnectivityTest.java
@@ -38,7 +38,7 @@ import org.gdms.data.values.Value;
 import org.gdms.data.values.ValueFactory;
 import org.gdms.driver.DataSet;
 import org.gdms.driver.memory.MemoryDataSetDriver;
-import org.gdms.gdmstopology.TopologySetUpTest;
+import org.gdms.gdmstopology.TopologySetupTest;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.orbisgis.progress.NullProgressMonitor;
@@ -47,7 +47,7 @@ import org.orbisgis.progress.NullProgressMonitor;
  *
  * @author Erwan Bocher
  */
-public class ConnectivityTest extends TopologySetUpTest {
+public class ConnectivityTest extends TopologySetupTest {
 
     @Test
     public void testST_BlockIdentity() throws Exception {

--- a/src/test/java/org/gdms/gdmstopology/function/GraphAnalysisTest.java
+++ b/src/test/java/org/gdms/gdmstopology/function/GraphAnalysisTest.java
@@ -45,7 +45,7 @@ import org.gdms.data.values.ValueFactory;
 import org.gdms.driver.DataSet;
 import org.gdms.driver.DriverException;
 import org.gdms.driver.memory.MemoryDataSetDriver;
-import org.gdms.gdmstopology.TopologySetUpTest;
+import org.gdms.gdmstopology.TopologySetupTest;
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.Graphs;
 import org.jgrapht.graph.DefaultDirectedGraph;
@@ -59,7 +59,7 @@ import org.orbisgis.progress.NullProgressMonitor;
  *
  * @author Erwan Bocher
  */
-public class GraphAnalysisTest extends TopologySetUpTest {
+public class GraphAnalysisTest extends TopologySetupTest {
 
     /**
      * Tests finding the shortest path between neighboring vertices of a

--- a/src/test/java/org/gdms/gdmstopology/function/GraphBuilderTest.java
+++ b/src/test/java/org/gdms/gdmstopology/function/GraphBuilderTest.java
@@ -40,7 +40,7 @@ import org.gdms.data.types.TypeFactory;
 import org.gdms.data.values.Value;
 import org.gdms.data.values.ValueFactory;
 import org.gdms.driver.DataSet;
-import org.gdms.gdmstopology.TopologySetUpTest;
+import org.gdms.gdmstopology.TopologySetupTest;
 import org.junit.Test;
 import org.orbisgis.progress.NullProgressMonitor;
 
@@ -50,7 +50,7 @@ import static org.junit.Assert.*;
  *
  * @author Erwan Bocher
  */
-public class GraphBuilderTest extends TopologySetUpTest {
+public class GraphBuilderTest extends TopologySetupTest {
 
     /**
      * A test to validate the planar graph method with two polygons.

--- a/src/test/java/org/gdms/gdmstopology/function/GraphUtilitiesTest.java
+++ b/src/test/java/org/gdms/gdmstopology/function/GraphUtilitiesTest.java
@@ -40,7 +40,7 @@ import org.gdms.data.values.Value;
 import org.gdms.data.values.ValueFactory;
 import org.gdms.driver.DataSet;
 import org.gdms.driver.memory.MemoryDataSetDriver;
-import org.gdms.gdmstopology.TopologySetUpTest;
+import org.gdms.gdmstopology.TopologySetupTest;
 import org.orbisgis.progress.NullProgressMonitor;
 import org.junit.Test;
 
@@ -51,7 +51,7 @@ import static org.junit.Assert.*;
  *
  * @author Erwan Bocher
  */
-public class GraphUtilitiesTest extends TopologySetUpTest {
+public class GraphUtilitiesTest extends TopologySetupTest {
 
     @Test
     public void testFindReachableEdges() throws Exception {

--- a/src/test/java/org/gdms/gdmstopology/model/GraphModelTest.java
+++ b/src/test/java/org/gdms/gdmstopology/model/GraphModelTest.java
@@ -34,7 +34,7 @@ package org.gdms.gdmstopology.model;
 
 import org.junit.Test;
 import org.gdms.data.DataSource;
-import org.gdms.gdmstopology.TopologySetUpTest;
+import org.gdms.gdmstopology.TopologySetupTest;
 import org.orbisgis.progress.NullProgressMonitor;
 
 import static org.junit.Assert.*;
@@ -43,7 +43,7 @@ import static org.junit.Assert.*;
  *
  * @author Erwan Bocher
  */
-public class GraphModelTest extends TopologySetUpTest {
+public class GraphModelTest extends TopologySetupTest {
 
     /**
      * A test to wrap a DirectedWeightedMultigraph with JGrapht.

--- a/src/test/java/org/gdms/gdmstopology/utils/GraphWriterTest.java
+++ b/src/test/java/org/gdms/gdmstopology/utils/GraphWriterTest.java
@@ -34,7 +34,7 @@ package org.gdms.gdmstopology.utils;
 
 import java.io.File;
 import org.gdms.data.DataSource;
-import org.gdms.gdmstopology.TopologySetUpTest;
+import org.gdms.gdmstopology.TopologySetupTest;
 import org.jgrapht.Graph;
 import org.jgrapht.graph.DefaultEdge;
 import static org.junit.Assert.assertTrue;
@@ -44,7 +44,7 @@ import org.junit.Test;
  *
  * @author ebocher
  */
-public class GraphWriterTest extends TopologySetUpTest {
+public class GraphWriterTest extends TopologySetupTest {
 
         @Test
         public void saveAGraph() throws Exception {                

--- a/src/test/java/org/gdms/gdmstopology/utils/GraphWriterTest.java
+++ b/src/test/java/org/gdms/gdmstopology/utils/GraphWriterTest.java
@@ -48,7 +48,7 @@ public class GraphWriterTest extends TopologySetUpTest {
 
         @Test
         public void saveAGraph() throws Exception {                
-                String dirPath = backupDir.getAbsolutePath();
+                String dirPath = tmpFolder.getAbsolutePath();
                 String nodes = dirPath+ File.separator+"nodes.gdms";
                 String edges = dirPath+ File.separator+"edges.gdms";
                 Graph<Integer, DefaultEdge> graph = RandomGraphCreator.createRandomWeightedMultigraph(5, 10);


### PR DESCRIPTION
By changing where data sources are stored, we fix some tests that were failing on Jenkins.

We also take advantage of this opportunity to document `TopologySetupTest` (and rename it).
