### PR TITLE
Convert ST_ConnectedComponents to a table function

### DIFF
--- a/src/main/java/org/gdms/gdmstopology/function/ST_ConnectedComponents.java
+++ b/src/main/java/org/gdms/gdmstopology/function/ST_ConnectedComponents.java
@@ -194,10 +194,7 @@ public class ST_ConnectedComponents extends AbstractTableFunction {
     }
 
     /**
-     * Returns the name of this function. This name will be used in SQL
-     * statements.
-     *
-     * @return The name of this function.
+     * {@inheritDoc}
      */
     @Override
     public String getName() {
@@ -205,9 +202,7 @@ public class ST_ConnectedComponents extends AbstractTableFunction {
     }
 
     /**
-     * Returns an example query using this function.
-     *
-     * @return An example query using this function.
+     * {@inheritDoc}
      */
     @Override
     public String getSqlOrder() {
@@ -215,9 +210,7 @@ public class ST_ConnectedComponents extends AbstractTableFunction {
     }
 
     /**
-     * Returns a description of this function.
-     *
-     * @return A description of this function.
+     * {@inheritDoc}
      */
     @Override
     public String getDescription() {
@@ -225,14 +218,7 @@ public class ST_ConnectedComponents extends AbstractTableFunction {
     }
 
     /**
-     * Returns an array of all possible signatures of this function. Multiple
-     * signatures arise from some arguments being optional.
-     *
-     * <p> Possible signatures: <OL> <li>
-     * <code>(TABLE input_table, STRING 'weights_column', INT orientation)</code>
-     * </OL>
-     *
-     * @return An array of all possible signatures of this function.
+     * {@inheritDoc}
      */
     @Override
     public FunctionSignature[] getFunctionSignatures() {

--- a/src/main/java/org/gdms/gdmstopology/function/ST_ConnectedComponents.java
+++ b/src/main/java/org/gdms/gdmstopology/function/ST_ConnectedComponents.java
@@ -33,15 +33,17 @@
 package org.gdms.gdmstopology.function;
 
 import org.gdms.data.DataSourceFactory;
+import org.gdms.data.schema.Metadata;
 import org.gdms.data.values.Value;
 import org.gdms.driver.DataSet;
+import org.gdms.driver.DriverException;
 import org.gdms.gdmstopology.model.GraphEdge;
 import org.gdms.gdmstopology.process.GraphConnectivityUtilities;
 import org.gdms.sql.function.FunctionException;
 import org.gdms.sql.function.FunctionSignature;
 import org.gdms.sql.function.ScalarArgument;
-import org.gdms.sql.function.executor.AbstractExecutorFunction;
 import org.gdms.sql.function.executor.ExecutorFunctionSignature;
+import org.gdms.sql.function.table.AbstractTableFunction;
 import org.gdms.sql.function.table.TableArgument;
 import org.gdms.sql.function.table.TableDefinition;
 import org.jgrapht.alg.ConnectivityInspector;
@@ -76,7 +78,7 @@ import org.orbisgis.progress.ProgressMonitor;
  *
  * @author Adam Gouge
  */
-public class ST_ConnectedComponents extends AbstractExecutorFunction {
+public class ST_ConnectedComponents extends AbstractTableFunction {
 
     /**
      * The name of this function.
@@ -157,7 +159,7 @@ public class ST_ConnectedComponents extends AbstractExecutorFunction {
      *               calculation.
      */
     @Override
-    public void evaluate(
+    public DataSet evaluate(
             DataSourceFactory dsf,
             DataSet[] tables,
             Value[] values,
@@ -183,7 +185,7 @@ public class ST_ConnectedComponents extends AbstractExecutorFunction {
                     pm);
             // Record a new table listing all the vertices and to which
             // connected component they belong.
-            GraphConnectivityUtilities.
+            return GraphConnectivityUtilities.
                     registerConnectedComponents(dsf, inspector);
         } catch (Exception ex) {
             System.out.println(ex);
@@ -222,18 +224,6 @@ public class ST_ConnectedComponents extends AbstractExecutorFunction {
         return DESCRIPTION;
     }
 
-//    /**
-//     * Returns the {@link Metadata} of the result of this function without
-//     * executing the query.
-//     *
-//     * @param tables {@link Metadata} objects of the input tables.
-//     * @return The {@link Metadata} of the result.
-//     * @throws DriverException
-//     */
-//    @Override
-//    public Metadata getMetadata(Metadata[] tables) throws DriverException {
-//        return GraphMetadataFactory.createClosenessCentralityMetadata();
-//    }
     /**
      * Returns an array of all possible signatures of this function. Multiple
      * signatures arise from some arguments being optional.
@@ -247,10 +237,18 @@ public class ST_ConnectedComponents extends AbstractExecutorFunction {
     @Override
     public FunctionSignature[] getFunctionSignatures() {
         return new FunctionSignature[]{
-                    new ExecutorFunctionSignature(
-                    new TableArgument(TableDefinition.GEOMETRY),
-                    ScalarArgument.STRING,
-                    ScalarArgument.INT)
-                };
+            new ExecutorFunctionSignature(
+            new TableArgument(TableDefinition.GEOMETRY),
+            ScalarArgument.STRING,
+            ScalarArgument.INT)
+        };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Metadata getMetadata(Metadata[] tables) throws DriverException {
+        return GraphConnectivityUtilities.createMetadata();
     }
 }

--- a/src/main/java/org/gdms/gdmstopology/function/ST_ConnectedComponents.java
+++ b/src/main/java/org/gdms/gdmstopology/function/ST_ConnectedComponents.java
@@ -61,14 +61,17 @@ import org.orbisgis.progress.ProgressMonitor;
  *
  * <p> Example usage: <center>
  * <code>
- * SELECT * FROM ST_ConnectedComponents(input_table[, orientation]);
+ * SELECT * FROM ST_ConnectedComponents(input_table, 'weights_column'
+ * [, orientation]);
  * </code> </center>
  *
- * <p> Required parameter: <ul> <li>
+ * <p> Required parameters: <ul> <li>
  * <code>input_table</code> - the input table. Specifically, this is the
  * <code>output_table_prefix.edges</code> table produced by {@link ST_Graph},
  * except that an additional column specifying the weight of each edge must be
- * added. </ul>
+ * added.
+ * <li>
+ * <code>'weights_column'</code> - the weights column.</ul>
  * <p> Optional parameter: <ul> <li>
  * <code>orientation</code> - an integer specifying the orientation of the
  * graph: <ul> <li> 1 if the graph is directed, <li> 2 if it is directed and we
@@ -89,7 +92,8 @@ public class ST_ConnectedComponents extends AbstractTableFunction {
      */
     private static final String SQL_ORDER =
             "SELECT * FROM ST_ConnectedComponents("
-            + "input_table"
+            + "input_table, "
+            + "'weights_column'"
             + "[, orientation]);";
     /**
      * Short description of this function.
@@ -106,14 +110,17 @@ public class ST_ConnectedComponents extends AbstractTableFunction {
             + "which lists all the vertices and to which "
             + "connected component they belong. "
             + "<p> "
-            + "Required parameter: "
+            + "Required parameters: "
             + "<ul> "
             + "<li> "
             + "<code>input_table</code> - the input table. "
             + "Specifically, this is the "
             + "<code>output_table_prefix.edges</code> "
             + "table produced by "
-            + "<code>ST_Graph</code>. </ul>"
+            + "<code>ST_Graph</code>. "
+            + "<li> "
+            + "<code>'weights_column'</code> - the name of the weights "
+            + "column. </ul>"
             + "<p> "
             + "Optional parameter: "
             + "<ul> "
@@ -169,14 +176,17 @@ public class ST_ConnectedComponents extends AbstractTableFunction {
         try {
             // Recover the DataSet.
             final DataSet dataSet = tables[0];
+            // Set the weights column name.
+            final String weightsColumn = values[0].getAsString();
             // Get the orientation
-            parseOptionalArgument(values[0]);
+            parseOptionalArgument(values[1]);
             // Create the ConnectivityInspector.
             ConnectivityInspector<Integer, GraphEdge> inspector =
                     GraphConnectivityUtilities.
                     getConnectivityInspector(
                     dsf,
                     dataSet,
+                    weightsColumn,
                     orientation,
                     pm);
             // Record a new table listing all the vertices and to which
@@ -245,11 +255,13 @@ public class ST_ConnectedComponents extends AbstractTableFunction {
             // No orientation specified.
             new TableFunctionSignature(
             TableDefinition.ANY,
-            TableArgument.GEOMETRY),
+            TableArgument.GEOMETRY,
+            ScalarArgument.STRING),
             // Specify orientation.
             new TableFunctionSignature(
             TableDefinition.ANY,
             TableArgument.GEOMETRY,
+            ScalarArgument.STRING,
             ScalarArgument.INT)
         };
     }

--- a/src/main/java/org/gdms/gdmstopology/function/ST_ConnectedComponents.java
+++ b/src/main/java/org/gdms/gdmstopology/function/ST_ConnectedComponents.java
@@ -59,8 +59,7 @@ import org.orbisgis.progress.ProgressMonitor;
  * <p> Example usage: <center>
  * <code>
  * EXECUTE ST_ConnectedComponents(input_table,
- * 'weights_column',
- * orientation);
+ *  orientation);
  * </code> </center>
  *
  * <p> Required parameters: <ul> <li>
@@ -68,8 +67,6 @@ import org.orbisgis.progress.ProgressMonitor;
  * <code>output_table_prefix.edges</code> table produced by {@link ST_Graph},
  * except that an additional column specifying the weight of each edge must be
  * added. <li>
- * <code>'weights_column'</code> - a string specifying the name of the column of
- * the input table that gives the weight of each edge. <li>
  * <code>orientation</code> - an integer specifying the orientation of the
  * graph: <ul> <li> 1 if the graph is directed, <li> 2 if it is directed and we
  * wish to reverse the orientation of the edges, <li> 3 if the graph is
@@ -90,7 +87,6 @@ public class ST_ConnectedComponents extends AbstractTableFunction {
     private static final String SQL_ORDER =
             "EXECUTE ST_ConnectedComponents("
             + "input_table, "
-            + "'weights_column', "
             + "orientation);";
     /**
      * Short description of this function.
@@ -114,13 +110,7 @@ public class ST_ConnectedComponents extends AbstractTableFunction {
             + "Specifically, this is the "
             + "<code>output_table_prefix.edges</code> "
             + "table produced by "
-            + "<code>ST_Graph</code>, "
-            + "except that an additional column specifying the weight "
-            + "of each edge must be added. "
-            + "<li> "
-            + "<code>'weights_column'</code> - "
-            + "a string specifying the name of the column of the input "
-            + "table that gives the weight of each edge. "
+            + "<code>ST_Graph</code>. "
             + "<li> "
             + "<code>orientation</code> - "
             + "an integer specifying the orientation of the graph: "
@@ -168,19 +158,14 @@ public class ST_ConnectedComponents extends AbstractTableFunction {
         try {
             // Recover the DataSet.
             final DataSet dataSet = tables[0];
-            // Set the weights column name.
-            String weightsColumn = values[0].getAsString();
-            // Set the output table prefix.
-//            String outputTablePrefix = values[1].getAsString();
             // Get the orientation
-            int orientation = values[1].getAsInt();
+            int orientation = values[0].getAsInt();
             // Create the ConnectivityInspector.
             ConnectivityInspector<Integer, GraphEdge> inspector =
                     GraphConnectivityUtilities.
                     getConnectivityInspector(
                     dsf,
                     dataSet,
-                    weightsColumn,
                     orientation,
                     pm);
             // Record a new table listing all the vertices and to which

--- a/src/main/java/org/gdms/gdmstopology/process/GraphConnectivityUtilities.java
+++ b/src/main/java/org/gdms/gdmstopology/process/GraphConnectivityUtilities.java
@@ -82,6 +82,7 @@ public class GraphConnectivityUtilities extends GraphAnalysis {
     public static ConnectivityInspector<Integer, GraphEdge> getConnectivityInspector(
             DataSourceFactory dsf,
             DataSet dataSet,
+            String weightColumnName,
             int graphType,
             ProgressMonitor pm) throws DriverException,
             GraphException {
@@ -89,16 +90,19 @@ public class GraphConnectivityUtilities extends GraphAnalysis {
         if (graphType == GraphSchema.DIRECT) {
             DWMultigraphDataSource dWMultigraphDataSource =
                     new DWMultigraphDataSource(dsf, dataSet, pm);
+            dWMultigraphDataSource.setWeightFieldIndex(weightColumnName);
             return new ConnectivityInspector(dWMultigraphDataSource);
         } else if (graphType == GraphSchema.DIRECT_REVERSED) {
             DWMultigraphDataSource dWMultigraphDataSource =
                     new DWMultigraphDataSource(dsf, dataSet, pm);
+            dWMultigraphDataSource.setWeightFieldIndex(weightColumnName);
             EdgeReversedGraphDataSource edgeReversedGraph =
                     new EdgeReversedGraphDataSource(dWMultigraphDataSource);
             return new ConnectivityInspector(edgeReversedGraph);
         } else if (graphType == GraphSchema.UNDIRECT) {
             WMultigraphDataSource wMultigraphDataSource =
                     new WMultigraphDataSource(dsf, dataSet, pm);
+            wMultigraphDataSource.setWeightFieldIndex(weightColumnName);
             return new ConnectivityInspector(wMultigraphDataSource);
         } else {
             throw new GraphException("Only three types of graphs "

--- a/src/main/java/org/gdms/gdmstopology/process/GraphConnectivityUtilities.java
+++ b/src/main/java/org/gdms/gdmstopology/process/GraphConnectivityUtilities.java
@@ -82,7 +82,6 @@ public class GraphConnectivityUtilities extends GraphAnalysis {
     public static ConnectivityInspector<Integer, GraphEdge> getConnectivityInspector(
             DataSourceFactory dsf,
             DataSet dataSet,
-            String weightColumnName,
             int graphType,
             ProgressMonitor pm) throws DriverException,
             GraphException {
@@ -90,19 +89,16 @@ public class GraphConnectivityUtilities extends GraphAnalysis {
         if (graphType == GraphSchema.DIRECT) {
             DWMultigraphDataSource dWMultigraphDataSource =
                     new DWMultigraphDataSource(dsf, dataSet, pm);
-            dWMultigraphDataSource.setWeightFieldIndex(weightColumnName);
             return new ConnectivityInspector(dWMultigraphDataSource);
         } else if (graphType == GraphSchema.DIRECT_REVERSED) {
             DWMultigraphDataSource dWMultigraphDataSource =
                     new DWMultigraphDataSource(dsf, dataSet, pm);
-            dWMultigraphDataSource.setWeightFieldIndex(weightColumnName);
             EdgeReversedGraphDataSource edgeReversedGraph =
                     new EdgeReversedGraphDataSource(dWMultigraphDataSource);
             return new ConnectivityInspector(edgeReversedGraph);
         } else if (graphType == GraphSchema.UNDIRECT) {
             WMultigraphDataSource wMultigraphDataSource =
                     new WMultigraphDataSource(dsf, dataSet, pm);
-            wMultigraphDataSource.setWeightFieldIndex(weightColumnName);
             return new ConnectivityInspector(wMultigraphDataSource);
         } else {
             throw new GraphException("Only three types of graphs "

--- a/src/main/java/org/gdms/gdmstopology/process/GraphConnectivityUtilities.java
+++ b/src/main/java/org/gdms/gdmstopology/process/GraphConnectivityUtilities.java
@@ -59,7 +59,7 @@ import org.orbisgis.progress.ProgressMonitor;
  *
  * @author Adam Gouge
  */
-public class GraphConnectivityUtilities extends GraphAnalysis {
+public class GraphConnectivityUtilities {
 
     /**
      * Returns a JGraphT {@link ConnectivityInspector} on a given graph.


### PR DESCRIPTION
This PR converts ST_ConnectedComponents to a table function. I have tested it in OrbisGIS and it is working. It also makes the graph orientation an optional argument.

This fixes irstv/gdms-topology#14.
