### PR TITLE
Write tests for ST_GraphAnalysis

### DIFF
--- a/src/main/java/org/gdms/gdmstopology/functionhelpers/ExecutorFunctionHelper.java
+++ b/src/main/java/org/gdms/gdmstopology/functionhelpers/ExecutorFunctionHelper.java
@@ -89,9 +89,7 @@ public abstract class ExecutorFunctionHelper extends FunctionHelper {
      * @throws DriverException
      */
     private void writeToTable(DiskBufferDriver driver,
-                                String outputTablePrefix) throws DriverException {
-        // TODO: Necessary?
-//        driver.open();
+                              String outputTablePrefix) throws DriverException {
         // Register the result in a new output table.
         String outputTableName = dsf.getSourceManager().
                 getUniqueName(

--- a/src/main/java/org/gdms/gdmstopology/functionhelpers/ExecutorFunctionHelper.java
+++ b/src/main/java/org/gdms/gdmstopology/functionhelpers/ExecutorFunctionHelper.java
@@ -37,6 +37,8 @@ import org.gdms.data.DataSourceFactory;
 import org.gdms.driver.DiskBufferDriver;
 import org.gdms.driver.DriverException;
 import org.orbisgis.progress.ProgressMonitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A helper class to store the results calculated by an executor function.
@@ -46,6 +48,9 @@ import org.orbisgis.progress.ProgressMonitor;
  * @author Adam Gouge
  */
 public abstract class ExecutorFunctionHelper extends FunctionHelper {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(ExecutorFunctionHelper.class);
 
     /**
      * Constructor.
@@ -83,10 +88,10 @@ public abstract class ExecutorFunctionHelper extends FunctionHelper {
      *
      * @throws DriverException
      */
-    private String writeToTable(DiskBufferDriver driver,
+    private void writeToTable(DiskBufferDriver driver,
                                 String outputTablePrefix) throws DriverException {
         // TODO: Necessary?
-        driver.open();
+//        driver.open();
         // Register the result in a new output table.
         String outputTableName = dsf.getSourceManager().
                 getUniqueName(
@@ -95,7 +100,7 @@ public abstract class ExecutorFunctionHelper extends FunctionHelper {
         dsf.getSourceManager().register(
                 outputTableName,
                 driver.getFile());
-        return outputTableName;
+        LOGGER.info("Table stored as {}", outputTableName);
     }
 
     /**

--- a/src/main/java/org/gdms/gdmstopology/graphcreator/GraphCreator.java
+++ b/src/main/java/org/gdms/gdmstopology/graphcreator/GraphCreator.java
@@ -243,9 +243,9 @@ public class GraphCreator<V extends VId, E extends Edge> {
             endNodeIndex = md.getFieldIndex(GraphSchema.END_NODE);
             verifyIndex(endNodeIndex, GraphSchema.END_NODE);
         } catch (DriverException ex) {
-            LOGGER.trace(METADATA_ERROR, ex);
+            LOGGER.error(METADATA_ERROR, ex);
         } catch (IndexException ex) {
-            LOGGER.trace("Problem with indices.", ex);
+            LOGGER.error("Problem with indices.", ex);
         }
         return md;
     }

--- a/src/main/java/org/gdms/gdmstopology/graphcreator/WeightedGraphCreator.java
+++ b/src/main/java/org/gdms/gdmstopology/graphcreator/WeightedGraphCreator.java
@@ -104,9 +104,9 @@ public class WeightedGraphCreator<V extends VId, E extends Edge>
                 throw new IllegalStateException(METADATA_ERROR);
             }
         } catch (IndexException ex) {
-            LOGGER.trace("Problem with indices.", ex);
+            LOGGER.error("Problem with indices.", ex);
         } catch (DriverException ex) {
-            LOGGER.trace(METADATA_ERROR, ex);
+            LOGGER.error(METADATA_ERROR, ex);
         }
         return md;
     }

--- a/src/main/java/org/gdms/gdmstopology/parse/GraphFunctionParser.java
+++ b/src/main/java/org/gdms/gdmstopology/parse/GraphFunctionParser.java
@@ -37,6 +37,8 @@ import org.gdms.data.types.Type;
 import org.gdms.data.values.Value;
 import org.gdms.gdmstopology.model.GraphSchema;
 import org.gdms.sql.function.FunctionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A helper class to parse {@link Value} arguments for SQL functions related to
@@ -45,6 +47,9 @@ import org.gdms.sql.function.FunctionException;
  * @author Adam Gouge
  */
 public class GraphFunctionParser {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(GraphFunctionParser.class);
 
     /**
      * Return the name of the weights column or null for unweighted graphs.
@@ -62,7 +67,7 @@ public class GraphFunctionParser {
         if (slotType == Type.INT) {
             final int allWeightsOneInt = value.getAsInt();
             if (allWeightsOneInt == 1) {
-                System.out.println("Setting all weights equal to 1.");
+                LOGGER.debug("Setting all weights equal to 1.");
                 weights = null;
             } else { // We only accept 1 or a string.
                 throw new IllegalArgumentException(
@@ -72,9 +77,8 @@ public class GraphFunctionParser {
         } else if (slotType == Type.STRING) {
             // Set the weights column name.
             weights = value.getAsString();
-            System.out.println("Setting the weight column name "
-                    + "to be \'" + weights
-                    + "\'.");
+            LOGGER.debug("Setting the weight column name to be \'{}\'.",
+                         weights);
         } else {
             throw new IllegalArgumentException(
                     "Either enter 1 to set all weights equal to 1 "
@@ -96,14 +100,15 @@ public class GraphFunctionParser {
         final int slotType = value.getType();
         if (slotType == Type.INT) {
             final int orientation = value.getAsInt();
-            System.out.print("Setting the orientation "
-                    + "to be ");
-            if (orientation == GraphSchema.DIRECT) {
-                System.out.println("directed.");
-            } else if (orientation == GraphSchema.DIRECT_REVERSED) {
-                System.out.println("reversed.");
-            } else if (orientation == GraphSchema.UNDIRECT) {
-                System.out.println("undirected.");
+            if (LOGGER.isDebugEnabled()) {
+                String graphType = (orientation == GraphSchema.DIRECT)
+                        ? "directed"
+                        : (orientation == GraphSchema.DIRECT_REVERSED)
+                        ? "reversed"
+                        : (orientation == GraphSchema.UNDIRECT)
+                        ? "undirected"
+                        : "ERROR";
+                LOGGER.debug("Setting the orientation to be {}.", graphType);
             }
             return orientation;
         } else {
@@ -162,8 +167,7 @@ public class GraphFunctionParser {
      */
     public static int parseSource(Value value) {
         final int source = parseVertex(value);
-        System.out.println("Setting the source "
-                + "to be " + source + ".");
+        LOGGER.debug("Setting the source to be {}.", source);
         return source;
     }
 
@@ -178,8 +182,7 @@ public class GraphFunctionParser {
      */
     public static int parseTarget(Value value) {
         final int target = parseVertex(value);
-        System.out.println("Setting the target "
-                + "to be " + target + ".");
+        LOGGER.debug("Setting the target to be {}.", target);
         return target;
     }
 }

--- a/src/test/java/org/gdms/gdmstopology/centrality/ST_GraphAnalysisTest.java
+++ b/src/test/java/org/gdms/gdmstopology/centrality/ST_GraphAnalysisTest.java
@@ -1,0 +1,199 @@
+/**
+ * GDMS-Topology is a library dedicated to graph analysis. It is based on the
+ * JGraphT library available at <http://www.jgrapht.org/>. It enables computing
+ * and processing large graphs using spatial and alphanumeric indexes.
+ *
+ * This version is developed at French IRSTV Institute as part of the EvalPDU
+ * project, funded by the French Agence Nationale de la Recherche (ANR) under
+ * contract ANR-08-VILL-0005-01 and GEBD project funded by the French Ministry
+ * of Ecology and Sustainable Development.
+ *
+ * GDMS-Topology is distributed under GPL 3 license. It is produced by the
+ * "Atelier SIG" team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR
+ * 2488.
+ *
+ * Copyright (C) 2009-2013 IRSTV (FR CNRS 2488)
+ *
+ * GDMS-Topology is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * GDMS-Topology is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * GDMS-Topology. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://wwwc.orbisgis.org/> or contact
+ * directly: info_at_orbisgis.org
+ */
+package org.gdms.gdmstopology.centrality;
+
+import org.gdms.data.DataSource;
+import org.gdms.data.values.Value;
+import org.gdms.data.values.ValueFactory;
+import org.gdms.driver.DataSet;
+import org.gdms.driver.DriverException;
+import org.gdms.gdmstopology.TopologySetupTest;
+import org.gdms.gdmstopology.model.GraphSchema;
+import org.gdms.sql.function.FunctionException;
+import org.junit.Test;
+import org.orbisgis.progress.NullProgressMonitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author Adam Gouge
+ */
+public class ST_GraphAnalysisTest extends TopologySetupTest {
+
+    private static final String LENGTH = "length";
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(ST_GraphAnalysisTest.class);
+
+    @Test
+    public void unweightedDirectedTest() {
+        try {
+            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
+                     ValueFactory.createValue(1),
+                     GraphSchema.DIRECT);
+        } catch (Exception ex) {
+        }
+        //        if (CHECK_RESULTS) {
+        //            checkBetweenness(new double[]{
+        //                1.0, 0.0, 1.0,
+        //                0.0, 0.0, 0.6666666666666666}, graph);
+        //            checkCloseness(new double[]{
+        //                0.0, 0.4166666666666667, 0.0,
+        //        }
+        //        }
+    }
+
+    @Test
+    public void unweightedReversedTest() {
+        try {
+            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
+                     ValueFactory.createValue(1),
+                     GraphSchema.DIRECT_REVERSED);
+        } catch (Exception ex) {
+        }
+//        if (CHECK_RESULTS) {
+//            checkBetweenness(new double[]{
+//                0.375, 0.0, 1.0,
+//                0.0, 0.0, 1.0}, graph);
+//            checkCloseness(new double[]{
+//                0.0, 0.0, 0.0,
+//                0.0, 0.0, 0.0}, graph);
+//        }
+    }
+
+    @Test
+    public void unweightedUndirectedTest() throws DriverException {
+        try {
+            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
+                     ValueFactory.createValue(1),
+                     GraphSchema.UNDIRECT);
+        } catch (Exception ex) {
+        }
+//        if (CHECK_RESULTS) {
+//            checkBetweenness(new double[]{
+//                0.5, 0.0, 1.0,
+//                0.0, 0.0, 0.75}, graph);
+//            checkCloseness(new double[]{
+//                0.5, 0.4166666666666667, 0.625,}
+//        }
+    }
+
+    @Test
+    public void weightedDirectedTest() {
+        try {
+            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
+                     ValueFactory.createValue(LENGTH),
+                     GraphSchema.DIRECT);
+        } catch (Exception ex) {
+        }
+//        if (CHECK_RESULTS) {
+//            checkBetweenness(new double[]{
+//                0.75, 0.0, 1.0,
+//                0.0, 0.0, 1.0}, graph);
+//            checkCloseness(new double[]{
+//                0.0, 0.0035327735482214143, 0.0,
+//                0.0, 0.0, 0.0}, graph);
+//        }
+    }
+
+    @Test
+    public void weightedReversedTest() {
+        try {
+            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
+                     ValueFactory.createValue(LENGTH),
+                     GraphSchema.DIRECT_REVERSED);
+        } catch (Exception ex) {
+        }
+//        if (CHECK_RESULTS) {
+//            checkBetweenness(new double[]{
+//                0.75, 0.0, 1.0,
+//                0.0, 0.0, 1.0}, graph);
+//            checkCloseness(new double[]{
+//                0.0, 0.0, 0.0,
+//                0.0, 0.0, 0.0}, graph);
+//        }
+    }
+
+    @Test
+    public void weightedUndirectedTest() {
+        try {
+            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
+                     ValueFactory.createValue(LENGTH),
+                     GraphSchema.UNDIRECT);
+        } catch (Exception ex) {
+        }
+//        if (CHECK_RESULTS) {
+//            checkBetweenness(new double[]{
+//                0.5714285714285714, 0.0, 1.0,
+//                0.0, 0.0, 0.8571428571428571}, graph);
+//
+//            checkCloseness(new double[]{
+//                0.003787491035823884, 0.0035327735482214143, 0.0055753940798198886,
+//                0.0032353723348164448, 0.003495002741097083, 0.0055753940798198886
+//            }, graph);
+//        }
+    }
+
+    private void evaluate(DataSource ds, Value weight, int graphType) {
+        String orientation = "Orientation: ";
+        orientation += (graphType == GraphSchema.UNDIRECT)
+                ? " Undirected."
+                : (graphType == GraphSchema.DIRECT)
+                ? " Directed."
+                : (graphType == GraphSchema.DIRECT_REVERSED)
+                ? " Reversed."
+                : " Invalid";
+        LOGGER.debug(orientation);
+        try {
+            ds.open();
+        } catch (DriverException ex) {
+            LOGGER.info("Could not open datasource.");
+        }
+        DataSet[] tables = new DataSet[]{ds};
+        try {
+            new ST_GraphAnalysis().evaluate(
+                    dsf,
+                    tables,
+                    new Value[]{weight,
+                ValueFactory.createValue(graphType)},
+                    new NullProgressMonitor());
+        } catch (FunctionException ex) {
+            LOGGER.error("Impossible to perform graph analysis.");
+        }
+        try {
+            ds.close();
+        } catch (DriverException ex) {
+            LOGGER.info("Could not close datasource.");
+        }
+    }
+}

--- a/src/test/java/org/gdms/gdmstopology/centrality/ST_GraphAnalysisTest.java
+++ b/src/test/java/org/gdms/gdmstopology/centrality/ST_GraphAnalysisTest.java
@@ -33,6 +33,9 @@
 package org.gdms.gdmstopology.centrality;
 
 import org.gdms.data.DataSource;
+import org.gdms.data.DataSourceCreationException;
+import org.gdms.data.DataSourceIterator;
+import org.gdms.data.NoSuchTableException;
 import org.gdms.data.values.Value;
 import org.gdms.data.values.ValueFactory;
 import org.gdms.driver.DataSet;
@@ -44,136 +47,37 @@ import org.junit.Test;
 import org.orbisgis.progress.NullProgressMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import static org.junit.Assert.assertEquals;
 
 /**
+ * Tests {@link ST_GraphAnalysis} on a 2D graph for all combinations of
+ * (un)weighted, (un)directed/reversed.
  *
  * @author Adam Gouge
  */
 public class ST_GraphAnalysisTest extends TopologySetupTest {
 
     private static final String LENGTH = "length";
+    private static final String UNWEIGHTED_NAME =
+            "output.unweighted.graph_analysis";
+    private static final String WEIGHTED_NAME =
+            "output.weighted.graph_analysis";
+    private static final double TOLERANCE = 0.0;
     private static final Logger LOGGER =
             LoggerFactory.getLogger(ST_GraphAnalysisTest.class);
 
-    @Test
-    public void unweightedDirectedTest() {
-        try {
-            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
-                     ValueFactory.createValue(1),
-                     GraphSchema.DIRECT);
-        } catch (Exception ex) {
-        }
-        //        if (CHECK_RESULTS) {
-        //            checkBetweenness(new double[]{
-        //                1.0, 0.0, 1.0,
-        //                0.0, 0.0, 0.6666666666666666}, graph);
-        //            checkCloseness(new double[]{
-        //                0.0, 0.4166666666666667, 0.0,
-        //        }
-        //        }
-    }
-
-    @Test
-    public void unweightedReversedTest() {
-        try {
-            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
-                     ValueFactory.createValue(1),
-                     GraphSchema.DIRECT_REVERSED);
-        } catch (Exception ex) {
-        }
-//        if (CHECK_RESULTS) {
-//            checkBetweenness(new double[]{
-//                0.375, 0.0, 1.0,
-//                0.0, 0.0, 1.0}, graph);
-//            checkCloseness(new double[]{
-//                0.0, 0.0, 0.0,
-//                0.0, 0.0, 0.0}, graph);
-//        }
-    }
-
-    @Test
-    public void unweightedUndirectedTest() throws DriverException {
-        try {
-            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
-                     ValueFactory.createValue(1),
-                     GraphSchema.UNDIRECT);
-        } catch (Exception ex) {
-        }
-//        if (CHECK_RESULTS) {
-//            checkBetweenness(new double[]{
-//                0.5, 0.0, 1.0,
-//                0.0, 0.0, 0.75}, graph);
-//            checkCloseness(new double[]{
-//                0.5, 0.4166666666666667, 0.625,}
-//        }
-    }
-
-    @Test
-    public void weightedDirectedTest() {
-        try {
-            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
-                     ValueFactory.createValue(LENGTH),
-                     GraphSchema.DIRECT);
-        } catch (Exception ex) {
-        }
-//        if (CHECK_RESULTS) {
-//            checkBetweenness(new double[]{
-//                0.75, 0.0, 1.0,
-//                0.0, 0.0, 1.0}, graph);
-//            checkCloseness(new double[]{
-//                0.0, 0.0035327735482214143, 0.0,
-//                0.0, 0.0, 0.0}, graph);
-//        }
-    }
-
-    @Test
-    public void weightedReversedTest() {
-        try {
-            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
-                     ValueFactory.createValue(LENGTH),
-                     GraphSchema.DIRECT_REVERSED);
-        } catch (Exception ex) {
-        }
-//        if (CHECK_RESULTS) {
-//            checkBetweenness(new double[]{
-//                0.75, 0.0, 1.0,
-//                0.0, 0.0, 1.0}, graph);
-//            checkCloseness(new double[]{
-//                0.0, 0.0, 0.0,
-//                0.0, 0.0, 0.0}, graph);
-//        }
-    }
-
-    @Test
-    public void weightedUndirectedTest() {
-        try {
-            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
-                     ValueFactory.createValue(LENGTH),
-                     GraphSchema.UNDIRECT);
-        } catch (Exception ex) {
-        }
-//        if (CHECK_RESULTS) {
-//            checkBetweenness(new double[]{
-//                0.5714285714285714, 0.0, 1.0,
-//                0.0, 0.0, 0.8571428571428571}, graph);
-//
-//            checkCloseness(new double[]{
-//                0.003787491035823884, 0.0035327735482214143, 0.0055753940798198886,
-//                0.0032353723348164448, 0.003495002741097083, 0.0055753940798198886
-//            }, graph);
-//        }
-    }
-
-    private void evaluate(DataSource ds, Value weight, int graphType) {
-        String orientation = "Orientation: ";
-        orientation += (graphType == GraphSchema.UNDIRECT)
-                ? " Undirected."
-                : (graphType == GraphSchema.DIRECT)
-                ? " Directed."
-                : (graphType == GraphSchema.DIRECT_REVERSED)
-                ? " Reversed."
-                : " Invalid";
-        LOGGER.debug(orientation);
+    /**
+     * Evaluates {@link ST_GraphAnalysis} on the given datasource considered as
+     * a(n) (un)weighted graph with the given edge orientation.
+     *
+     * @param ds          Datasource
+     * @param weight      1 or weight column name
+     * @param orientation Orientation
+     *
+     * @see GraphSchema.DIRECT, GraphSchema.DIRECT_REVERSED,
+     * GraphSchema.UNDIRECT
+     */
+    private void evaluate(DataSource ds, Value weight, int orientation) {
         try {
             ds.open();
         } catch (DriverException ex) {
@@ -185,7 +89,7 @@ public class ST_GraphAnalysisTest extends TopologySetupTest {
                     dsf,
                     tables,
                     new Value[]{weight,
-                ValueFactory.createValue(graphType)},
+                ValueFactory.createValue(orientation)},
                     new NullProgressMonitor());
         } catch (FunctionException ex) {
             LOGGER.error("Impossible to perform graph analysis.");
@@ -194,6 +98,292 @@ public class ST_GraphAnalysisTest extends TopologySetupTest {
             ds.close();
         } catch (DriverException ex) {
             LOGGER.info("Could not close datasource.");
+        }
+    }
+
+    @Test
+    public void unweightedDirectedTest() throws DriverException {
+        try {
+            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
+                     ValueFactory.createValue(1),
+                     GraphSchema.DIRECT);
+        } catch (Exception ex) {
+        }
+        // CHECK RESULTS       
+        DataSource result = null;
+        try {
+            result = dsf.getDataSource(UNWEIGHTED_NAME);
+            result.open();
+        } catch (NoSuchTableException ex) {
+            LOGGER.info("Table {} not found.", UNWEIGHTED_NAME);
+        } catch (DataSourceCreationException ex) {
+            LOGGER.info("Could not create datasource for {}", UNWEIGHTED_NAME);
+        } catch (DriverException ex) {
+            LOGGER.info("Could not open datasource {}", UNWEIGHTED_NAME);
+        }
+        if (result != null) {
+            DataSourceIterator it = result.iterator();
+            while (it.hasNext()) {
+                Value[] row = it.next();
+                int id = row[0].getAsInt();
+                double betweenness = row[1].getAsDouble();
+                double closeness = row[2].getAsDouble();
+                if (id == 2 || id == 4 || id == 5) {
+                    assertEquals(0.0, betweenness, TOLERANCE);
+                } else if (id == 1 || id == 3) {
+                    assertEquals(1.0, betweenness, TOLERANCE);
+                } else if (id == 6) {
+                    assertEquals(0.6666666666666666, betweenness, TOLERANCE);
+                } else {
+                    LOGGER.error("Unexpected vertex {}", id);
+                }
+                if (id == 1 || id == 3 || id == 4 || id == 5 || id == 6) {
+                    assertEquals(0.0, closeness, TOLERANCE);
+                } else if (id == 2) {
+                    assertEquals(0.4166666666666667, closeness, TOLERANCE);
+                } else {
+                    LOGGER.error("Unexpected vertex {}", id);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void unweightedReversedTest() {
+        try {
+            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
+                     ValueFactory.createValue(1),
+                     GraphSchema.DIRECT_REVERSED);
+        } catch (Exception ex) {
+        }
+        // CHECK RESULTS       
+        DataSource result = null;
+        try {
+            result = dsf.getDataSource(UNWEIGHTED_NAME);
+            result.open();
+        } catch (NoSuchTableException ex) {
+            LOGGER.info("Table {} not found.", UNWEIGHTED_NAME);
+        } catch (DataSourceCreationException ex) {
+            LOGGER.info("Could not create datasource for {}", UNWEIGHTED_NAME);
+        } catch (DriverException ex) {
+            LOGGER.info("Could not open datasource {}", UNWEIGHTED_NAME);
+        }
+        if (result != null) {
+            DataSourceIterator it = result.iterator();
+            while (it.hasNext()) {
+                Value[] row = it.next();
+                int id = row[0].getAsInt();
+                double betweenness = row[1].getAsDouble();
+                double closeness = row[2].getAsDouble();
+                if (id == 2 || id == 4 || id == 5) {
+                    assertEquals(0.0, betweenness, TOLERANCE);
+                } else if (id == 3 || id == 6) {
+                    assertEquals(1.0, betweenness, TOLERANCE);
+                } else if (id == 1) {
+                    assertEquals(0.375, betweenness, TOLERANCE);
+                } else {
+                    LOGGER.error("Unexpected vertex {}", id);
+                }
+                // All vertices have closeness zero.
+                assertEquals(0.0, closeness, TOLERANCE);
+            }
+        }
+    }
+
+    @Test
+    public void unweightedUndirectedTest() {
+        try {
+            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
+                     ValueFactory.createValue(1),
+                     GraphSchema.UNDIRECT);
+        } catch (Exception ex) {
+        }
+        // CHECK RESULTS       
+        DataSource result = null;
+        try {
+            result = dsf.getDataSource(UNWEIGHTED_NAME);
+            result.open();
+        } catch (NoSuchTableException ex) {
+            LOGGER.info("Table {} not found.", UNWEIGHTED_NAME);
+        } catch (DataSourceCreationException ex) {
+            LOGGER.info("Could not create datasource for {}", UNWEIGHTED_NAME);
+        } catch (DriverException ex) {
+            LOGGER.info("Could not open datasource {}", UNWEIGHTED_NAME);
+        }
+        if (result != null) {
+            DataSourceIterator it = result.iterator();
+            while (it.hasNext()) {
+                Value[] row = it.next();
+                int id = row[0].getAsInt();
+                double betweenness = row[1].getAsDouble();
+                double closeness = row[2].getAsDouble();
+                if (id == 2 || id == 4 || id == 5) {
+                    assertEquals(0.0, betweenness, TOLERANCE);
+                } else if (id == 3) {
+                    assertEquals(1.0, betweenness, TOLERANCE);
+                } else if (id == 6) {
+                    assertEquals(0.75, betweenness, TOLERANCE);
+                } else if (id == 1) {
+                    assertEquals(0.5, betweenness, TOLERANCE);
+                } else {
+                    LOGGER.error("Unexpected vertex {}", id);
+                }
+                if (id == 3 || id == 6) {
+                    assertEquals(0.625, closeness, TOLERANCE);
+                } else if (id == 2 || id == 5) {
+                    assertEquals(0.4166666666666667, closeness, TOLERANCE);
+                } else if (id == 1) {
+                    assertEquals(0.5, closeness, TOLERANCE);
+                } else if (id == 4) {
+                    assertEquals(0.35714285714285715, closeness, TOLERANCE);
+                } else {
+                    LOGGER.error("Unexpected vertex {}", id);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void weightedDirectedTest() {
+        try {
+            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
+                     ValueFactory.createValue(LENGTH),
+                     GraphSchema.DIRECT);
+        } catch (Exception ex) {
+        }
+        // CHECK RESULTS       
+        DataSource result = null;
+        try {
+            result = dsf.getDataSource(WEIGHTED_NAME);
+            result.open();
+        } catch (NoSuchTableException ex) {
+            LOGGER.info("Table {} not found.", WEIGHTED_NAME);
+        } catch (DataSourceCreationException ex) {
+            LOGGER.info("Could not create datasource for {}", WEIGHTED_NAME);
+        } catch (DriverException ex) {
+            LOGGER.info("Could not open datasource {}", WEIGHTED_NAME);
+        }
+        if (result != null) {
+            DataSourceIterator it = result.iterator();
+            while (it.hasNext()) {
+                Value[] row = it.next();
+                int id = row[0].getAsInt();
+                double betweenness = row[1].getAsDouble();
+                double closeness = row[2].getAsDouble();
+                if (id == 2 || id == 4 || id == 5) {
+                    assertEquals(0.0, betweenness, TOLERANCE);
+                } else if (id == 3 || id == 6) {
+                    assertEquals(1.0, betweenness, TOLERANCE);
+                } else if (id == 1) {
+                    assertEquals(0.75, betweenness, TOLERANCE);
+                } else {
+                    LOGGER.error("Unexpected vertex {}", id);
+                }
+                if (id == 1 || id == 3 || id == 4 || id == 5 || id == 6) {
+                    assertEquals(0.0, closeness, TOLERANCE);
+                } else if (id == 2) {
+                    assertEquals(0.0035327735482214143, closeness, TOLERANCE);
+                } else {
+                    LOGGER.error("Unexpected vertex {}", id);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void weightedReversedTest() {
+        try {
+            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
+                     ValueFactory.createValue(LENGTH),
+                     GraphSchema.DIRECT_REVERSED);
+        } catch (Exception ex) {
+        }
+        // CHECK RESULTS       
+        DataSource result = null;
+        try {
+            result = dsf.getDataSource(WEIGHTED_NAME);
+            result.open();
+        } catch (NoSuchTableException ex) {
+            LOGGER.info("Table {} not found.", WEIGHTED_NAME);
+        } catch (DataSourceCreationException ex) {
+            LOGGER.info("Could not create datasource for {}", WEIGHTED_NAME);
+        } catch (DriverException ex) {
+            LOGGER.info("Could not open datasource {}", WEIGHTED_NAME);
+        }
+        if (result != null) {
+            DataSourceIterator it = result.iterator();
+            while (it.hasNext()) {
+                Value[] row = it.next();
+                int id = row[0].getAsInt();
+                double betweenness = row[1].getAsDouble();
+                double closeness = row[2].getAsDouble();
+                if (id == 2 || id == 4 || id == 5) {
+                    assertEquals(0.0, betweenness, TOLERANCE);
+                } else if (id == 3 || id == 6) {
+                    assertEquals(1.0, betweenness, TOLERANCE);
+                } else if (id == 1) {
+                    assertEquals(0.75, betweenness, TOLERANCE);
+                } else {
+                    LOGGER.error("Unexpected vertex {}", id);
+                }
+                // All vertices have closeness zero.
+                assertEquals(0.0, closeness, TOLERANCE);
+            }
+        }
+    }
+
+    @Test
+    public void weightedUndirectedTest() {
+        try {
+            evaluate(dsf.getDataSource(GRAPH2D_EDGES),
+                     ValueFactory.createValue(LENGTH),
+                     GraphSchema.UNDIRECT);
+        } catch (Exception ex) {
+        }
+        // CHECK RESULTS       
+        DataSource result = null;
+        try {
+            result = dsf.getDataSource(WEIGHTED_NAME);
+            result.open();
+        } catch (NoSuchTableException ex) {
+            LOGGER.info("Table {} not found.", WEIGHTED_NAME);
+        } catch (DataSourceCreationException ex) {
+            LOGGER.info("Could not create datasource for {}", WEIGHTED_NAME);
+        } catch (DriverException ex) {
+            LOGGER.info("Could not open datasource {}", WEIGHTED_NAME);
+        }
+        if (result != null) {
+            DataSourceIterator it = result.iterator();
+            while (it.hasNext()) {
+                Value[] row = it.next();
+                int id = row[0].getAsInt();
+                double betweenness = row[1].getAsDouble();
+                double closeness = row[2].getAsDouble();
+                if (id == 2 || id == 4 || id == 5) {
+                    assertEquals(0.0, betweenness, TOLERANCE);
+                } else if (id == 3) {
+                    assertEquals(1.0, betweenness, TOLERANCE);
+                } else if (id == 1) {
+                    assertEquals(0.5714285714285714, betweenness, TOLERANCE);
+                } else if (id == 6) {
+                    assertEquals(0.8571428571428571, betweenness, TOLERANCE);
+                } else {
+                    LOGGER.error("Unexpected vertex {}", id);
+                }
+                if (id == 3 || id == 6) {
+                    assertEquals(0.0055753940798198886, closeness, TOLERANCE);
+                } else if (id == 1) {
+                    assertEquals(0.003787491035823884, closeness, TOLERANCE);
+                } else if (id == 2) {
+                    assertEquals(0.0035327735482214143, closeness, TOLERANCE);
+                } else if (id == 4) {
+                    assertEquals(0.0032353723348164448, closeness, TOLERANCE);
+                } else if (id == 5) {
+                    assertEquals(0.003495002741097083, closeness, TOLERANCE);
+                } else {
+                    LOGGER.error("Unexpected vertex {}", id);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
We changed the way results are obtained in JNA (result information is now contained in the vertices), so we had to update GDMS-Topology appropriately.

We also wrote more extensive test for ST_GraphAnalysis on a 2D graph.

Finally, a few System.out.println's were replaced by calls to loggers.

Fixes #30.
