### PR TITLE
Use jna-0.1.1 and slf-4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,7 @@
                 <dependency>
                         <groupId>org.javanetworkanalyzer</groupId>
                         <artifactId>java-network-analyzer</artifactId>
-                        <version>0.1.1-SNAPSHOT</version>
-                        <type>jar</type>
+                        <version>0.1.1</version>
                 </dependency>
                 <dependency> 
                         <groupId>org.slf4j</groupId>

--- a/src/main/java/org/gdms/gdmstopology/centrality/GraphAnalyzer.java
+++ b/src/main/java/org/gdms/gdmstopology/centrality/GraphAnalyzer.java
@@ -34,8 +34,6 @@ package org.gdms.gdmstopology.centrality;
 
 import org.javanetworkanalyzer.data.VCent;
 import java.util.Map;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.gdms.data.DataSourceFactory;
 import org.gdms.data.schema.DefaultMetadata;
 import org.gdms.data.schema.Metadata;
@@ -49,8 +47,11 @@ import org.gdms.driver.DriverException;
 import org.gdms.gdmstopology.functionhelpers.FunctionHelper;
 import org.gdms.gdmstopology.model.GraphSchema;
 import org.javanetworkanalyzer.data.PathLengthData;
+import org.javanetworkanalyzer.model.EdgeCent;
 import org.jgrapht.Graph;
 import org.orbisgis.progress.ProgressMonitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Calculates network parameters such as centrality indices on the nodes of a
@@ -58,7 +59,7 @@ import org.orbisgis.progress.ProgressMonitor;
  *
  * @author Adam Gouge
  */
-public abstract class GraphAnalyzer<V extends VCent, E, S extends PathLengthData>
+public abstract class GraphAnalyzer<V extends VCent, E extends EdgeCent, S extends PathLengthData>
         extends FunctionHelper {
 
     /**
@@ -91,18 +92,8 @@ public abstract class GraphAnalyzer<V extends VCent, E, S extends PathLengthData
         GraphSchema.ID,
         GraphSchema.BETWEENNESS_CENTRALITY,
         GraphSchema.CLOSENESS_CENTRALITY});
-    /**
-     * A logger.
-     */
-    protected static final Logger LOGGER;
-
-    /**
-     * Static block to set the logger level.
-     */
-    static {
-        LOGGER = Logger.getLogger(GraphAnalyzer.class);
-        LOGGER.setLevel(Level.TRACE);
-    }
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(GraphAnalyzer.class);
 
     /**
      * Constructs a new {@link GraphAnalyzer}.
@@ -148,7 +139,7 @@ public abstract class GraphAnalyzer<V extends VCent, E, S extends PathLengthData
         try {
             analyzer.computeAll();
         } catch (Exception ex) {
-            LOGGER.error("Problem doing graph analysis.", ex);
+            throw new IllegalStateException("Problem doing graph analysis.", ex);
         }
 
         Graph<V, E> graph = analyzer.getGraph();

--- a/src/main/java/org/gdms/gdmstopology/centrality/UnweightedGraphAnalyzer.java
+++ b/src/main/java/org/gdms/gdmstopology/centrality/UnweightedGraphAnalyzer.java
@@ -32,18 +32,18 @@
  */
 package org.gdms.gdmstopology.centrality;
 
-import org.javanetworkanalyzer.data.VUCent;
-import org.javanetworkanalyzer.progress.DefaultProgressMonitor;
 import org.gdms.data.DataSourceFactory;
 import org.gdms.driver.DataSet;
 import org.gdms.driver.DriverException;
-import static org.gdms.gdmstopology.centrality.GraphAnalyzer.ANALYZER_PREP_ERROR;
-import static org.gdms.gdmstopology.centrality.GraphAnalyzer.LOGGER;
 import org.gdms.gdmstopology.graphcreator.GraphCreator;
 import org.gdms.gdmstopology.model.GraphException;
 import org.javanetworkanalyzer.data.UnweightedPathLengthData;
-import org.javanetworkanalyzer.model.Edge;
+import org.javanetworkanalyzer.data.VUCent;
+import org.javanetworkanalyzer.model.EdgeCent;
+import org.javanetworkanalyzer.progress.DefaultProgressMonitor;
 import org.orbisgis.progress.ProgressMonitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link GraphAnalyzer} for unweighted graphs.
@@ -51,9 +51,11 @@ import org.orbisgis.progress.ProgressMonitor;
  * @author Adam Gouge
  */
 public class UnweightedGraphAnalyzer
-        extends GraphAnalyzer<VUCent, Edge, UnweightedPathLengthData> {
+        extends GraphAnalyzer<VUCent, EdgeCent, UnweightedPathLengthData> {
 
     protected final String edgeOrientationColumnName;
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(UnweightedGraphAnalyzer.class);
 
     /**
      * Constructs a new {@link UnweightedGraphAnalyzer}.
@@ -101,14 +103,14 @@ public class UnweightedGraphAnalyzer
      * {@inheritDoc}
      */
     @Override
-    protected org.javanetworkanalyzer.analyzers.UnweightedGraphAnalyzer<Edge> prepareAnalyzer() {
+    protected org.javanetworkanalyzer.analyzers.UnweightedGraphAnalyzer<EdgeCent> prepareAnalyzer() {
         try {
             return new org.javanetworkanalyzer.analyzers.UnweightedGraphAnalyzer(
                     new GraphCreator(dataSet,
                                      orientation,
                                      edgeOrientationColumnName,
                                      VUCent.class,
-                                     Edge.class).prepareGraph(),
+                                     EdgeCent.class).prepareGraph(),
                     new DefaultProgressMonitor());
         } catch (Exception ex) {
             LOGGER.trace(ANALYZER_PREP_ERROR, ex);

--- a/src/main/java/org/gdms/gdmstopology/centrality/WeightedGraphAnalyzer.java
+++ b/src/main/java/org/gdms/gdmstopology/centrality/WeightedGraphAnalyzer.java
@@ -32,18 +32,19 @@
  */
 package org.gdms.gdmstopology.centrality;
 
-import org.javanetworkanalyzer.data.VWCent;
-import org.javanetworkanalyzer.progress.DefaultProgressMonitor;
 import org.gdms.data.DataSourceFactory;
 import org.gdms.driver.DataSet;
 import org.gdms.driver.DriverException;
-import static org.gdms.gdmstopology.centrality.GraphAnalyzer.ANALYZER_PREP_ERROR;
-import static org.gdms.gdmstopology.centrality.GraphAnalyzer.LOGGER;
 import org.gdms.gdmstopology.graphcreator.WeightedGraphCreator;
 import org.gdms.gdmstopology.model.GraphException;
+import org.javanetworkanalyzer.data.VWCent;
 import org.javanetworkanalyzer.data.WeightedPathLengthData;
 import org.javanetworkanalyzer.model.Edge;
+import org.javanetworkanalyzer.model.EdgeCent;
+import org.javanetworkanalyzer.progress.DefaultProgressMonitor;
 import org.orbisgis.progress.ProgressMonitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link GraphAnalyzer} for weighted graphs.
@@ -51,13 +52,15 @@ import org.orbisgis.progress.ProgressMonitor;
  * @author Adam Gouge
  */
 public class WeightedGraphAnalyzer
-        extends GraphAnalyzer<VWCent, Edge, WeightedPathLengthData> {
+        extends GraphAnalyzer<VWCent, EdgeCent, WeightedPathLengthData> {
 
     /**
      * The name of the weight column.
      */
     private final String weightColumnName;
     protected final String edgeOrientationColumnName;
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(WeightedGraphAnalyzer.class);
 
     /**
      * Constructs a new {@link WeightedGraphAnalyzer}.
@@ -110,14 +113,14 @@ public class WeightedGraphAnalyzer
      * {@inheritDoc}
      */
     @Override
-    protected org.javanetworkanalyzer.analyzers.WeightedGraphAnalyzer<Edge> prepareAnalyzer() {
+    protected org.javanetworkanalyzer.analyzers.WeightedGraphAnalyzer<EdgeCent> prepareAnalyzer() {
         try {
             return new org.javanetworkanalyzer.analyzers.WeightedGraphAnalyzer(
                     new WeightedGraphCreator(dataSet,
                                              orientation,
                                              edgeOrientationColumnName,
                                              VWCent.class,
-                                             Edge.class,
+                                             EdgeCent.class,
                                              weightColumnName).prepareGraph(),
                     new DefaultProgressMonitor());
         } catch (Exception ex) {

--- a/src/main/java/org/gdms/gdmstopology/model/GDMSGraph.java
+++ b/src/main/java/org/gdms/gdmstopology/model/GDMSGraph.java
@@ -33,10 +33,6 @@
 package org.gdms.gdmstopology.model;
 
 import com.vividsolutions.jts.geom.Geometry;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
-import org.apache.log4j.Logger;
 import org.gdms.data.DataSourceFactory;
 import org.gdms.data.NoSuchTableException;
 import org.gdms.data.indexes.DefaultAlphaQuery;
@@ -51,6 +47,12 @@ import org.jgrapht.EdgeFactory;
 import org.jgrapht.graph.AbstractGraph;
 import org.jgrapht.graph.ClassBasedEdgeFactory;
 import org.orbisgis.progress.ProgressMonitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
 
 /**
  * A (JGraphT) graph created from an existing data source.
@@ -82,7 +84,8 @@ public final class GDMSGraph
     /**
      * Used to log possible errors encountered when initializing the index.
      */
-    private static final Logger LOGGER = Logger.getLogger(GDMSGraph.class);
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(GDMSGraph.class);
     /**
      * Used to recover the set of vertices.
      */


### PR DESCRIPTION
Here we use the tagged version of jna instead of the snapshot. We also
remove all old usages of log4j and replace them by slf-4j.

This should fix the failing build after agouge/java-network-analyzer#39.
