### PR TITLE
Use JNA for edge betweenness centrality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
                 <dependency>
                         <groupId>org.javanetworkanalyzer</groupId>
                         <artifactId>java-network-analyzer</artifactId>
-                        <version>0.1.1</version>
+                        <version>0.1.2</version>
                 </dependency>
                 <dependency> 
                         <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
         <groupId>org.gdms</groupId>
         <artifactId>gdms-topology</artifactId>
         <packaging>bundle</packaging>
-        <version>1.3-SNAPSHOT</version>
+        <version>1.3</version>
         <name>GDMS-Topology</name>
         <description>Tools for network analysis on transportation networks.</description>
         <url>http://www.github.com/agouge/gdms-topology</url>

--- a/src/main/java/org/gdms/gdmstopology/centrality/GraphAnalyzer.java
+++ b/src/main/java/org/gdms/gdmstopology/centrality/GraphAnalyzer.java
@@ -123,6 +123,11 @@ public abstract class GraphAnalyzer<V extends VCent, E extends EdgeCent, S exten
         return MD;
     }
 
+    /**
+     * Returns a {@link DiskBufferDriver} for edge betweenness centrality.
+     *
+     * @return A {@link DiskBufferDriver} for edge betweenness centrality
+     */
     public DiskBufferDriver getEdgesDriver()  {
         DiskBufferDriver edgesDriver = null;
         try {

--- a/src/main/java/org/gdms/gdmstopology/centrality/ST_GraphAnalysis.java
+++ b/src/main/java/org/gdms/gdmstopology/centrality/ST_GraphAnalysis.java
@@ -79,7 +79,7 @@ public class ST_GraphAnalysis extends AbstractExecutorFunction {
      * The SQL order of this function.
      */
     private static final String SQL_ORDER =
-            "SELECT * FROM " + NAME + "("
+            "EXECUTE " + NAME + "("
             + "output.edges"
             + "[, 'weights_column']"
             + "[, " + POSSIBLE_ORIENTATIONS + "]);";
@@ -215,9 +215,9 @@ public class ST_GraphAnalysis extends AbstractExecutorFunction {
         final DiskBufferDriver nodesDriver = analyzer.prepareDataSet();
         final DiskBufferDriver edgesDriver = analyzer.getEdgesDriver();
         final SourceManager sourceManager = dsf.getSourceManager();
-        sourceManager.register("node_centrality",
+        sourceManager.register(sourceManager.getUniqueName("node_centrality"),
                 nodesDriver.getFile());
-        sourceManager.register("edge_centrality",
+        sourceManager.register(sourceManager.getUniqueName("edge_centrality"),
                 edgesDriver.getFile());
     }
 

--- a/src/main/java/org/gdms/gdmstopology/centrality/ST_GraphAnalysis.java
+++ b/src/main/java/org/gdms/gdmstopology/centrality/ST_GraphAnalysis.java
@@ -36,6 +36,7 @@ import org.gdms.data.DataSourceFactory;
 import org.gdms.data.schema.Metadata;
 import org.gdms.data.values.Value;
 import org.gdms.driver.DataSet;
+import org.gdms.driver.DiskBufferDriver;
 import org.gdms.driver.DriverException;
 import org.gdms.gdmstopology.function.ST_ShortestPathLength;
 import static org.gdms.gdmstopology.function.ST_ShortestPathLength.DIRECTED;
@@ -47,9 +48,11 @@ import org.gdms.gdmstopology.model.GraphException;
 import org.gdms.gdmstopology.model.GraphSchema;
 import org.gdms.gdmstopology.parse.GraphFunctionParser;
 import org.gdms.gdmstopology.utils.ArrayConcatenator;
+import org.gdms.source.SourceManager;
 import org.gdms.sql.function.FunctionException;
 import org.gdms.sql.function.FunctionSignature;
 import org.gdms.sql.function.ScalarArgument;
+import org.gdms.sql.function.executor.AbstractExecutorFunction;
 import org.gdms.sql.function.executor.ExecutorFunctionSignature;
 import org.gdms.sql.function.table.AbstractTableFunction;
 import org.gdms.sql.function.table.TableArgument;
@@ -66,7 +69,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Adam Gouge
  */
-public class ST_GraphAnalysis extends AbstractTableFunction {
+public class ST_GraphAnalysis extends AbstractExecutorFunction {
 
     /**
      * The name of this function.
@@ -158,14 +161,14 @@ public class ST_GraphAnalysis extends AbstractTableFunction {
      * @throws FunctionException
      */
     @Override
-    public DataSet evaluate(
+    public void evaluate(
             DataSourceFactory dsf,
             DataSet[] tables,
             Value[] values,
             ProgressMonitor pm) {
         final DataSet edges = tables[0];
         parseArguments(edges, tables, values);
-        return doAnalysisAccordingToUserInput(dsf, edges, pm);
+        doAnalysisAccordingToUserInput(dsf, edges, pm);
     }
 
     /**
@@ -180,7 +183,7 @@ public class ST_GraphAnalysis extends AbstractTableFunction {
      * @throws GraphException
      * @throws DriverException
      */
-    private DataSet doAnalysisAccordingToUserInput(
+    private void doAnalysisAccordingToUserInput(
             DataSourceFactory dsf,
             DataSet edges,
             ProgressMonitor pm) {
@@ -207,7 +210,15 @@ public class ST_GraphAnalysis extends AbstractTableFunction {
                 new WeightedGraphAnalyzer(
                 dsf, edges, pm, graphType, edgeOrientationColumnName,
                 weightsColumn);
-        return analyzer.prepareDataSet();
+
+        // Nodes table
+        final DiskBufferDriver nodesDriver = analyzer.prepareDataSet();
+        final DiskBufferDriver edgesDriver = analyzer.getEdgesDriver();
+        final SourceManager sourceManager = dsf.getSourceManager();
+        sourceManager.register("node_centrality",
+                nodesDriver.getFile());
+        sourceManager.register("edge_centrality",
+                edgesDriver.getFile());
     }
 
     /**
@@ -311,11 +322,6 @@ public class ST_GraphAnalysis extends AbstractTableFunction {
             weight,
             ScalarArgument.INT,
             ScalarArgument.STRING)};
-    }
-
-    @Override
-    public Metadata getMetadata(Metadata[] tables) throws DriverException {
-        return GraphAnalyzer.MD;
     }
 
     /**

--- a/src/main/java/org/gdms/gdmstopology/centrality/ST_GraphAnalysis.java
+++ b/src/main/java/org/gdms/gdmstopology/centrality/ST_GraphAnalysis.java
@@ -211,12 +211,13 @@ public class ST_GraphAnalysis extends AbstractExecutorFunction {
                 dsf, edges, pm, graphType, edgeOrientationColumnName,
                 weightsColumn);
 
+        final SourceManager sourceManager = dsf.getSourceManager();
         // Nodes table
         final DiskBufferDriver nodesDriver = analyzer.prepareDataSet();
-        final DiskBufferDriver edgesDriver = analyzer.getEdgesDriver();
-        final SourceManager sourceManager = dsf.getSourceManager();
         sourceManager.register(sourceManager.getUniqueName("node_centrality"),
                 nodesDriver.getFile());
+        // Edges table
+        final DiskBufferDriver edgesDriver = analyzer.getEdgesDriver();
         sourceManager.register(sourceManager.getUniqueName("edge_centrality"),
                 edgesDriver.getFile());
     }

--- a/src/main/java/org/gdms/gdmstopology/graphcreator/WeightedGraphCreator.java
+++ b/src/main/java/org/gdms/gdmstopology/graphcreator/WeightedGraphCreator.java
@@ -156,11 +156,12 @@ public class WeightedGraphCreator<V extends VId, E extends Edge>
     protected E loadDoubleEdge(Value[] row,
                                KeyedGraph<V, E> graph,
                                final int startNode,
-                               final int endNode) {
+                               final int endNode,
+                               final int edgeID) {
         // In directed graphs, undirected edges are represented
         // by directed edges in both directions.
-        E edgeTo = graph.addEdge(startNode, endNode);
-        E edgeFrom = graph.addEdge(endNode, startNode);
+        E edgeTo = graph.addEdge(startNode, endNode, edgeID);
+        E edgeFrom = graph.addEdge(endNode, startNode, -edgeID);
         double weight = row[weightFieldIndex].getAsDouble();
         edgeTo.setWeight(weight);
         edgeFrom.setWeight(weight);

--- a/src/main/java/org/gdms/gdmstopology/process/NetworkGraphBuilder.java
+++ b/src/main/java/org/gdms/gdmstopology/process/NetworkGraphBuilder.java
@@ -197,7 +197,7 @@ public class NetworkGraphBuilder {
             int startIndex = edgeMedata.getFieldIndex(GraphSchema.START_NODE);
             int endIndex = edgeMedata.getFieldIndex(GraphSchema.END_NODE);
             // COUNTERS
-            int edgeGID = 0;
+            int edgeGID = 1;
             int nodesGID = 1;
 
             // Go through the DataSet.

--- a/src/test/java/org/gdms/gdmstopology/centrality/ST_GraphAnalysisTest.java
+++ b/src/test/java/org/gdms/gdmstopology/centrality/ST_GraphAnalysisTest.java
@@ -51,7 +51,9 @@ import org.junit.Test;
 import org.orbisgis.progress.NullProgressMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@link ST_GraphAnalysis} on a 2D graph for all combinations of
@@ -62,32 +64,31 @@ import static org.junit.Assert.assertEquals;
 public class ST_GraphAnalysisTest extends TopologySetupTest {
 
     private static final String LENGTH = "length";
-    private static final String UNWEIGHTED_NAME =
-            "output.unweighted.graph_analysis";
-    private static final String WEIGHTED_NAME =
-            "output.weighted.graph_analysis";
     private static final double TOLERANCE = 0.0;
     private static final Logger LOGGER =
             LoggerFactory.getLogger(ST_GraphAnalysisTest.class);
 
-    private DataSet unweightedAnalysis(String orientation)
+    private void unweightedAnalysis(String orientation)
             throws Exception {
-        return new ST_GraphAnalysis()
+        new ST_GraphAnalysis()
                 .evaluate(dsf,
-                          prepareTables(),
-                          new Value[]{ValueFactory.createValue(orientation)},
-                          new NullProgressMonitor());
+                        prepareTables(),
+                        new Value[]{ValueFactory.createValue(orientation)},
+                        new NullProgressMonitor());
     }
 
     @Test
     public void unweightedDirectedTest() throws Exception {
 
-        DataSet result = unweightedAnalysis(ST_ShortestPathLength.DIRECTED
-                                            + ST_ShortestPathLength.SEPARATOR
-                                            + GraphSchema.EDGE_ORIENTATION);
+        unweightedAnalysis(ST_ShortestPathLength.DIRECTED
+                + ST_ShortestPathLength.SEPARATOR
+                + GraphSchema.EDGE_ORIENTATION);
 
-        for (int i = 0; i < result.getRowCount(); i++) {
-            Value[] row = result.getRow(i);
+        DataSource nodes = dsf.getDataSource("node_centrality");
+        nodes.open();
+
+        for (int i = 0; i < nodes.getRowCount(); i++) {
+            Value[] row = nodes.getRow(i);
             int id = row[0].getAsInt();
             double betweenness = row[1].getAsDouble();
             double closeness = row[2].getAsDouble();
@@ -108,17 +109,45 @@ public class ST_GraphAnalysisTest extends TopologySetupTest {
                 LOGGER.error("Unexpected vertex {}", id);
             }
         }
+
+        nodes.close();
+
+        DataSource edges = dsf.getDataSource("edge_centrality");
+        edges.open();
+        assertTrue(edges.getRowCount() == 6);
+        for (int i = 0; i < edges.getRowCount(); i++) {
+            final Value[] row = edges.getRow(i);
+            final int id = row[0].getAsInt();
+            final double betweenness = row[1].getAsDouble();
+            if (id == 1) {
+                assertEquals(3.0 / 4, betweenness, TOLERANCE);
+            } else if (id == 2) {
+                assertEquals(0, betweenness, TOLERANCE);
+            } else if (id == 3) {
+                assertEquals(1, betweenness, TOLERANCE);
+            } else if (id == 4 || id == 5) {
+                assertEquals(1.0 / 4, betweenness, TOLERANCE);
+            } else if (id == 6) {
+                assertEquals(1.0 / 2, betweenness, TOLERANCE);
+            } else {
+                LOGGER.error("Unexpected edge {}", id);
+            }
+        }
+        edges.close();
     }
 
     @Test
     public void unweightedReversedTest() throws Exception {
 
-        DataSet result = unweightedAnalysis(ST_ShortestPathLength.REVERSED
-                                            + ST_ShortestPathLength.SEPARATOR
-                                            + GraphSchema.EDGE_ORIENTATION);
+        unweightedAnalysis(ST_ShortestPathLength.REVERSED
+                + ST_ShortestPathLength.SEPARATOR
+                + GraphSchema.EDGE_ORIENTATION);
 
-        for (int i = 0; i < result.getRowCount(); i++) {
-            Value[] row = result.getRow(i);
+        DataSource nodes = dsf.getDataSource("node_centrality");
+        nodes.open();
+
+        for (int i = 0; i < nodes.getRowCount(); i++) {
+            Value[] row = nodes.getRow(i);
             int id = row[0].getAsInt();
             double betweenness = row[1].getAsDouble();
             double closeness = row[2].getAsDouble();
@@ -134,15 +163,42 @@ public class ST_GraphAnalysisTest extends TopologySetupTest {
             // All vertices have closeness zero.
             assertEquals(0.0, closeness, TOLERANCE);
         }
+
+        nodes.close();
+
+        DataSource edges = dsf.getDataSource("edge_centrality");
+        edges.open();
+        assertTrue(edges.getRowCount() == 6);
+        for (int i = 0; i < edges.getRowCount(); i++) {
+            final Value[] row = edges.getRow(i);
+            final int id = row[0].getAsInt();
+            final double betweenness = row[1].getAsDouble();
+            if (id == 1) {
+                assertEquals(3.0 / 4, betweenness, TOLERANCE);
+            } else if (id == 2) {
+                assertEquals(0, betweenness, TOLERANCE);
+            } else if (id == 3) {
+                assertEquals(1, betweenness, TOLERANCE);
+            } else if (id == 4 || id == 5) {
+                assertEquals(1.0 / 4, betweenness, TOLERANCE);
+            } else if (id == 6) {
+                assertEquals(1.0 / 2, betweenness, TOLERANCE);
+            } else {
+                LOGGER.error("Unexpected edge {}", id);
+            }
+        }
     }
 
     @Test
     public void unweightedUndirectedTest() throws Exception {
 
-        DataSet result = unweightedAnalysis(ST_ShortestPathLength.UNDIRECTED);
+        unweightedAnalysis(ST_ShortestPathLength.UNDIRECTED);
 
-        for (int i = 0; i < result.getRowCount(); i++) {
-            Value[] row = result.getRow(i);
+        DataSource nodes = dsf.getDataSource("node_centrality");
+        nodes.open();
+
+        for (int i = 0; i < nodes.getRowCount(); i++) {
+            Value[] row = nodes.getRow(i);
             int id = row[0].getAsInt();
             double betweenness = row[1].getAsDouble();
             double closeness = row[2].getAsDouble();
@@ -169,28 +225,51 @@ public class ST_GraphAnalysisTest extends TopologySetupTest {
                 LOGGER.error("Unexpected vertex {}", id);
             }
         }
+
+        nodes.close();
+
+        DataSource edges = dsf.getDataSource("edge_centrality");
+        edges.open();
+        assertTrue(edges.getRowCount() == 6);
+        for (int i = 0; i < edges.getRowCount(); i++) {
+            final Value[] row = edges.getRow(i);
+            final int id = row[0].getAsInt();
+            final double betweenness = row[1].getAsDouble();
+            if (id == 1 || id == 2 || id == 6) {
+                assertEquals(1.0 / 5, betweenness, TOLERANCE);
+            } else if (id == 3) {
+                assertEquals(1, betweenness, TOLERANCE);
+            } else if (id == 4 || id == 5) {
+                assertEquals(0, betweenness, TOLERANCE);
+            } else {
+                LOGGER.error("Unexpected edge {}", id);
+            }
+        }
     }
 
-    private DataSet weightedAnalysis(String weight, String orientation)
+    private void weightedAnalysis(String weight, String orientation)
             throws Exception {
-        return new ST_GraphAnalysis()
+        new ST_GraphAnalysis()
                 .evaluate(dsf,
-                          prepareTables(),
-                          new Value[]{ValueFactory.createValue(weight),
-                                      ValueFactory.createValue(orientation)},
-                          new NullProgressMonitor());
+                        prepareTables(),
+                        new Value[]{ValueFactory.createValue(weight),
+                                ValueFactory.createValue(orientation)},
+                        new NullProgressMonitor());
     }
 
     @Test
     public void weightedDirectedTest() throws Exception {
 
-        DataSet result = weightedAnalysis(LENGTH,
-                                          ST_ShortestPathLength.DIRECTED
-                                          + ST_ShortestPathLength.SEPARATOR
-                                          + GraphSchema.EDGE_ORIENTATION);
+        weightedAnalysis(LENGTH,
+                ST_ShortestPathLength.DIRECTED
+                        + ST_ShortestPathLength.SEPARATOR
+                        + GraphSchema.EDGE_ORIENTATION);
 
-        for (int i = 0; i < result.getRowCount(); i++) {
-            Value[] row = result.getRow(i);
+        DataSource nodes = dsf.getDataSource("node_centrality");
+        nodes.open();
+
+        for (int i = 0; i < nodes.getRowCount(); i++) {
+            Value[] row = nodes.getRow(i);
             int id = row[0].getAsInt();
             double betweenness = row[1].getAsDouble();
             double closeness = row[2].getAsDouble();
@@ -211,18 +290,45 @@ public class ST_GraphAnalysisTest extends TopologySetupTest {
                 LOGGER.error("Unexpected vertex {}", id);
             }
         }
+
+        nodes.close();
+
+        DataSource edges = dsf.getDataSource("edge_centrality");
+        edges.open();
+        assertTrue(edges.getRowCount() == 6);
+        for (int i = 0; i < edges.getRowCount(); i++) {
+            final Value[] row = edges.getRow(i);
+            final int id = row[0].getAsInt();
+            final double betweenness = row[1].getAsDouble();
+            if (id == 1) {
+                assertEquals(5.0 / 6, betweenness, TOLERANCE);
+            } else if (id == 2) {
+                assertEquals(1.0 / 3, betweenness, TOLERANCE);
+            } else if (id == 3 || id == 4) {
+                assertEquals(1, betweenness, TOLERANCE);
+            } else if (id == 5) {
+                assertEquals(0, betweenness, TOLERANCE);
+            } else if (id == 6) {
+                assertEquals(2.0 / 3, betweenness, TOLERANCE);
+            } else {
+                LOGGER.error("Unexpected edge {}", id);
+            }
+        }
     }
 
     @Test
     public void weightedReversedTest() throws Exception {
 
-        DataSet result = weightedAnalysis(LENGTH,
-                                          ST_ShortestPathLength.REVERSED
-                                          + ST_ShortestPathLength.SEPARATOR
-                                          + GraphSchema.EDGE_ORIENTATION);
+        weightedAnalysis(LENGTH,
+                ST_ShortestPathLength.REVERSED
+                        + ST_ShortestPathLength.SEPARATOR
+                        + GraphSchema.EDGE_ORIENTATION);
 
-        for (int i = 0; i < result.getRowCount(); i++) {
-            Value[] row = result.getRow(i);
+        DataSource nodes = dsf.getDataSource("node_centrality");
+        nodes.open();
+
+        for (int i = 0; i < nodes.getRowCount(); i++) {
+            Value[] row = nodes.getRow(i);
             int id = row[0].getAsInt();
             double betweenness = row[1].getAsDouble();
             double closeness = row[2].getAsDouble();
@@ -238,17 +344,44 @@ public class ST_GraphAnalysisTest extends TopologySetupTest {
             // All vertices have closeness zero.
             assertEquals(0.0, closeness, TOLERANCE);
         }
+
+        nodes.close();
+
+        DataSource edges = dsf.getDataSource("edge_centrality");
+        edges.open();
+        assertTrue(edges.getRowCount() == 6);
+        for (int i = 0; i < edges.getRowCount(); i++) {
+            final Value[] row = edges.getRow(i);
+            final int id = row[0].getAsInt();
+            final double betweenness = row[1].getAsDouble();
+            if (id == 1) {
+                assertEquals(5.0 / 6, betweenness, TOLERANCE);
+            } else if (id == 2) {
+                assertEquals(1.0 / 3, betweenness, TOLERANCE);
+            } else if (id == 3 || id == 4) {
+                assertEquals(1, betweenness, TOLERANCE);
+            } else if (id == 5) {
+                assertEquals(0, betweenness, TOLERANCE);
+            } else if (id == 6) {
+                assertEquals(2.0 / 3, betweenness, TOLERANCE);
+            } else {
+                LOGGER.error("Unexpected edge {}", id);
+            }
+        }
     }
 
     @Test
     public void weightedUndirectedTest() throws Exception {
 
-        DataSet result = weightedAnalysis(LENGTH,
-                                          ST_ShortestPathLength.UNDIRECTED);
+        weightedAnalysis(LENGTH,
+                ST_ShortestPathLength.UNDIRECTED);
+
+        DataSource nodes = dsf.getDataSource("node_centrality");
+        nodes.open();
 
         // CHECK RESULTS
-        for (int i = 0; i < result.getRowCount(); i++) {
-            Value[] row = result.getRow(i);
+        for (int i = 0; i < nodes.getRowCount(); i++) {
+            Value[] row = nodes.getRow(i);
             int id = row[0].getAsInt();
             double betweenness = row[1].getAsDouble();
             double closeness = row[2].getAsDouble();
@@ -277,6 +410,28 @@ public class ST_GraphAnalysisTest extends TopologySetupTest {
                 LOGGER.error("Unexpected vertex {}", id);
             }
         }
+
+        nodes.close();
+
+        DataSource edges = dsf.getDataSource("edge_centrality");
+        edges.open();
+        assertTrue(edges.getRowCount() == 6);
+        for (int i = 0; i < edges.getRowCount(); i++) {
+            final Value[] row = edges.getRow(i);
+            final int id = row[0].getAsInt();
+            final double betweenness = row[1].getAsDouble();
+            if (id == 1 || id == 2 || id == 6) {
+                assertEquals(5.0 / 9, betweenness, TOLERANCE);
+            } else if (id == 3) {
+                assertEquals(1, betweenness, TOLERANCE);
+            } else if (id == 4) {
+                assertEquals(8.0 / 9, betweenness, TOLERANCE);
+            } else if (id == 5) {
+                assertEquals(0, betweenness, TOLERANCE);
+            } else {
+                LOGGER.error("Unexpected edge {}", id);
+            }
+        }
     }
 
     private DataSet[] prepareTables() throws DataSourceCreationException,
@@ -292,14 +447,14 @@ public class ST_GraphAnalysisTest extends TopologySetupTest {
             throws DriverException {
         DefaultMetadata newMetadata = new DefaultMetadata(edges.getMetadata());
         newMetadata.addField(GraphSchema.EDGE_ORIENTATION,
-                             TypeFactory.createType(Type.INT));
+                TypeFactory.createType(Type.INT));
         MemoryDataSetDriver newEdges =
                 new MemoryDataSetDriver(newMetadata);
         for (int i = 0; i < edges.getRowCount(); i++) {
             Value[] oldRow = edges.getRow(i);
             final Value[] newRow = new Value[newMetadata.getFieldCount()];
             System.arraycopy(oldRow, 0, newRow, 0,
-                             newMetadata.getFieldCount() - 1);
+                    newMetadata.getFieldCount() - 1);
             newRow[newMetadata.getFieldCount() - 1] =
                     ValueFactory.createValue(GraphCreator.DIRECTED_EDGE);
             newEdges.addValues(newRow);


### PR DESCRIPTION
Using JNA 0.1.2, we are now able to compute edge betweenness centrality in addition to node closeness and betweenness centrality when ST_GraphAnalysis is executed.
